### PR TITLE
increase upload limit to 100MB in nginx too

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -29,7 +29,7 @@ http {
 	types_hash_max_size 2048;
 
 	# Limit upload file size
-	client_max_body_size 1m;
+	client_max_body_size 100m;
 
 	index	index.php;
 


### PR DESCRIPTION
The configuration of php-fpm already allows uploads up to 100MB but the nginx.conf still limits uploads to 1MB. This PR increases the upload limit in nginx.conf too.