### PR TITLE
Upgrade to release 3.12.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:centos7
 
 ENV bludit_content /usr/share/nginx/html/bl-content
-ENV bludit_url https://www.bludit.com/releases/bludit-3-10-0.zip
+ENV bludit_url https://www.bludit.com/releases/bludit-3-12-0.zip
 
 ENV nginx_path /etc/nginx
 ENV nginx_conf ${nginx_path}/nginx.conf


### PR DESCRIPTION
Simple upgrade to 3.12.0 by updating the `bludit_url` environment variable in the Dockerfile.

Shouldn't break anything else in the docker build, which I tested by building and running it.