### PR TITLE
Docker security

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:centos7
 
 ENV bludit_content /usr/share/nginx/html/bl-content
-ENV bludit_url https://www.bludit.com/releases/bludit-3-13-1.zip
+ENV bludit_url https://www.bludit.com/releases/bludit-3-15-0.zip
 
 ENV nginx_path /etc/nginx
 ENV nginx_conf ${nginx_path}/nginx.conf
@@ -57,7 +57,7 @@ WORKDIR /tmp
 RUN curl -o /tmp/bludit.zip ${bludit_url} && \
 	unzip /tmp/bludit.zip && \
 	rm -rf /usr/share/nginx/html && \
-	cp -r bludit-* /usr/share/nginx/html && \
+	cp -r bludit /usr/share/nginx/html && \
 	chown -R nginx:nginx /usr/share/nginx/html && \
 	chmod 755 ${bludit_content} && \
 	sed -i "s/'DEBUG_MODE', FALSE/'DEBUG_MODE', TRUE/g" /usr/share/nginx/html/bl-kernel/boot/init.php && \

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To get access visit with your browser http://localhost:8000
 mkdir ~/bludit
 
 docker run --name bludit \
-    -p 8000:80 \
+    -p 127.0.0.1:8000:80 \
     -v ~/bludit:/usr/share/nginx/html/bl-content \
     -d bludit/docker:latest
 ```
@@ -32,7 +32,7 @@ mkdir ~/bludit-themes
 mkdir ~/bludit-plugins
 
 docker run --name bludit \
-    -p 8000:80 \
+    -p 127.0.0.1:8000:80 \
     -v ~/bludit:/usr/share/nginx/html/bl-content \
     -v ~/bludit-themes:/usr/share/nginx/html/bl-themes \
     -v ~/bludit-plugins:/usr/share/nginx/html/bl-plugins \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,7 +8,7 @@ if [[ "$(ls $theme_dir)" ]]; then
 else
   echo "bl-themes directory is empty, initializing..."
   echo "Copying theme files to $theme_dir"
-  cp -r /tmp/bludit-*/bl-themes/* $theme_dir
+  cp -r /tmp/bludit/bl-themes/* $theme_dir
   chown -R nginx. $theme_dir
 fi
 
@@ -17,9 +17,9 @@ if [[ "$(ls $plugin_dir)" ]]; then
 else
   echo "bl-plugins directory is empty, initializing..."
   echo "Copying plugin files to $plugin_dir"
-  cp -r /tmp/bludit-*/bl-plugins/* $plugin_dir
+  cp -r /tmp/bludit/bl-plugins/* $plugin_dir
   chown -R nginx. $plugin_dir
 fi
 
-rm -rf /tmp/bludit-*
+rm -rf /tmp/bludit
 exec /usr/bin/supervisord -n -c /etc/supervisord.conf


### PR DESCRIPTION
Provide a safer example of running the bludit container.

If not binded locally, docker can create iptables rules and expose the container to the internet. (https://askubuntu.com/questions/652556/uncomplicated-firewall-ufw-is-not-blocking-anything-when-using-docker)